### PR TITLE
ポケモン一覧のAPi作成

### DIFF
--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -1,0 +1,4 @@
+export const ERROR_MESSAGE = {
+  NOT_FOUND: "Invalid request: Pokemon data not found",
+  SUCCESS: "success",
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,1 @@
-const POKEMON_URL = "https://pokeapi.co/api/v2/";
+export const POKEMON_URL = "https://pokeapi.co/api/v2/pokemon/";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,6 @@
-export const POKEMON_URL = "https://pokeapi.co/api/v2/pokemon/";
+export const BASE_URL = "https://pokeapi.co/api/v2/";
+
+export const POKEMON_URL = {
+  DATA: `${BASE_URL}` + "pokemon/",
+  SPECIES: `${BASE_URL}` + "pokemon-species/",
+};

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -1,4 +1,4 @@
-import { PokemonDataType } from "../type/convertPokemon";
+import { PokemonDataType, SpritesType } from "../type/convertPokemon";
 
 /**
  * 数が多いので必要なデータだけを選択して返す
@@ -6,11 +6,38 @@ import { PokemonDataType } from "../type/convertPokemon";
  * @returns　特定の要素だけのデータ
  */
 export const convertPokemonData = (data: PokemonDataType) => {
-  console.log(data.stats);
+  const convertedData = convertKeys(data);
+
   return {
     id: data.id,
-    sprites: data.sprites,
+    sprites: convertedData.sprites,
     stats: data.stats,
     types: data.types,
   };
 };
+
+type TransformKey<T> = {
+  [K in keyof T as K extends string
+    ? K extends `${infer Start}-${infer End}`
+      ? `${Start}_${End}`
+      : K
+    : K]: T[K] extends Record<string, unknown> ? TransformKey<T[K]> : T[K];
+};
+
+/**
+ * 一部スネークケースになってなかったので、スネークケースに変換
+ */
+function convertKeys<T extends Record<string, unknown>>(
+  data: T
+): TransformKey<T> {
+  const result: any = {};
+
+  for (const key in data) {
+    const newKey = key.replace(/-/g, "_"); // ハイフンをアンダースコアに変換
+    const value = data[key];
+    result[newKey] =
+      value && typeof value === "object" ? convertKeys(value) : value;
+  }
+
+  return result;
+}

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -1,0 +1,16 @@
+import { PokemonDataType } from "../type/convertPokemon";
+
+/**
+ * 数が多いので必要なデータだけを選択して返す
+ * @param 取得しただけのデータ
+ * @returns　特定の要素だけのデータ
+ */
+export const convertPokemonData = (data: PokemonDataType) => {
+  console.log(data.stats);
+  return {
+    id: data.id,
+    sprites: data.sprites,
+    stats: data.stats,
+    types: data.types,
+  };
+};

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -1,15 +1,20 @@
 import { PokemonDataType, SpritesType } from "../type/convertPokemon";
+import { SpeciesListType } from "../type/pokemonSpecoes";
 
 /**
  * 数が多いので必要なデータだけを選択して返す
  * @param 取得しただけのデータ
  * @returns　特定の要素だけのデータ
  */
-export const convertPokemonData = (data: PokemonDataType) => {
+export const convertPokemonData = (
+  data: PokemonDataType,
+  names: SpeciesListType
+) => {
   const convertedData = convertKeys(data);
 
   return {
     id: data.id,
+    names: names,
     sprites: convertedData.sprites,
     stats: data.stats,
     types: data.types,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -52,7 +52,7 @@ export const fetchPokemon = async ({ id }: fetchPokemonType) => {
  * @param offset
  */
 export const fetchAllPokemon = async (offset: number) => {
-  const MAX_LIMIT = 30;
+  const MAX_LIMIT = 50;
 
   try {
     // 並列リクエストを実行

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,6 +1,7 @@
 import { POKEMON_URL } from "../constants";
 import { pokemonID } from "../type";
 import { PokemonDataType } from "../type/convertPokemon";
+import { PokemonSpecies } from "../type/pokemonSpecoes";
 import { convertPokemonData } from "./convert";
 
 type fetchPokemonType = {
@@ -9,8 +10,13 @@ type fetchPokemonType = {
 
 export const fetchPokemon = async ({ id }: fetchPokemonType) => {
   try {
-    const replaceFetchUrl = `${POKEMON_URL}${id}`;
+    const replaceFetchUrl = `${POKEMON_URL.DATA}${id}`;
     const result = await fetch(replaceFetchUrl);
+
+    const fetchSpeciesUrl = `${POKEMON_URL.SPECIES}${id}`;
+    const speciesResult = await fetch(fetchSpeciesUrl);
+    const pokemonSpeciesData: PokemonSpecies = await speciesResult.json();
+    const { names } = pokemonSpeciesData;
 
     if (!result.ok) {
       throw new Error(`HTTP error! status: ${result.status}`);
@@ -18,10 +24,62 @@ export const fetchPokemon = async ({ id }: fetchPokemonType) => {
 
     // レスポンスをJSONとしてパース
     const data: PokemonDataType = await result.json();
-    const convertedPokemonData = convertPokemonData(data);
+    const convertedPokemonData = convertPokemonData(data, names);
+
     return convertedPokemonData;
   } catch (error) {
     console.error("Failed to fetch Pokemon data:", error);
     throw error;
   }
 };
+
+// const fetchWithRetry = async (
+//   url: string,
+//   retries: number = 3
+// ): Promise<any> => {
+//   for (let attempt = 0; attempt < retries; attempt++) {
+//     try {
+//       const res = await fetch(url);
+//       if (!res.ok) {
+//         throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
+//       }
+//       return await res.json();
+//     } catch (error) {
+//       console.error(`Attempt ${attempt + 1} failed:`, error);
+//       if (attempt === retries - 1) throw error; // 最後の試行でも失敗した場合はエラーをスロー
+//     }
+//   }
+// };
+
+// const fetchBatch = async (ids: number[]): Promise<any[]> => {
+//   const requests = ids.map((id) => fetchWithRetry(`${POKEMON_URL}${id}`));
+//   return Promise.allSettled(requests).then((results) =>
+//     results
+//       .filter((result) => result.status === "fulfilled")
+//       .map((result) => (result as PromiseFulfilledResult<any>).value)
+//   );
+// };
+
+// export const fetchAllPokemon = async (): Promise<any[]> => {
+//   try {
+//     const batchSize = 10; // 一度に処理するバッチサイズ
+//     const max = 1026;
+//     const pokemonIds = Array.from({ length: 11 }, (_, i) => i + 1);
+//     const batches = [];
+
+//     for (let i = 0; i < pokemonIds.length; i += batchSize) {
+//       const batchIds = pokemonIds.slice(i, i + batchSize);
+//       batches.push(fetchBatch(batchIds));
+//     }
+
+//     const allPokemonData = (await Promise.all(batches)).flat();
+//     const convertedPokemonData = allPokemonData.map((data) =>
+//       convertPokemonData(data)
+//     );
+
+//     return convertedPokemonData;
+//   } catch (error) {
+//     console.error("Failed to fetch all Pokemon data:", error);
+//     throw error;
+//   }
+// };

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,24 @@
+import { POKEMON_URL } from "../constants";
+import { pokemonID } from "../type";
+
+type fetchPokemonType = {
+  id: pokemonID;
+};
+
+export const fetchPokemon = async ({ id }: fetchPokemonType) => {
+  try {
+    const replaceFetchUrl = `${POKEMON_URL}${id}`;
+    const result = await fetch(replaceFetchUrl);
+
+    if (!result.ok) {
+      throw new Error(`HTTP error! status: ${result.status}`);
+    }
+
+    // レスポンスをJSONとしてパース
+    const data = await result.json();
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch Pokemon data:", error);
+    throw error;
+  }
+};

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,5 +1,7 @@
 import { POKEMON_URL } from "../constants";
 import { pokemonID } from "../type";
+import { PokemonDataType } from "../type/convertPokemon";
+import { convertPokemonData } from "./convert";
 
 type fetchPokemonType = {
   id: pokemonID;
@@ -15,8 +17,9 @@ export const fetchPokemon = async ({ id }: fetchPokemonType) => {
     }
 
     // レスポンスをJSONとしてパース
-    const data = await result.json();
-    return data;
+    const data: PokemonDataType = await result.json();
+    const convertedPokemonData = convertPokemonData(data);
+    return convertedPokemonData;
   } catch (error) {
     console.error("Failed to fetch Pokemon data:", error);
     throw error;

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,1 +1,14 @@
-export const replacePokemonUrlParams = () => {};
+/**
+ * idとstatusだけを返す関数
+ * TODO:（後々指定できたほうが便利そう）
+ * @param query
+ * @returns
+ */
+export const replacePokemonUrlParams = (
+  query: Record<string, string>
+): { id?: string; status?: string } => {
+  // 必要なキーだけを抽出
+  const { id, status } = query;
+
+  return { id, status };
+};

--- a/src/pokemon/id.ts
+++ b/src/pokemon/id.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+
+const app = new Hono();
+app.use("*", requestId());
+
+// 動的パス定義
+app.get("/:id", async (c) => {
+  const id = c.req.param("id"); // URL の ":id" 部分を取得
+  console.log("Extracted ID:", id);
+
+  return c.text(`The ID is ${id}`);
+});
+
+export default app;

--- a/src/pokemon/index.ts
+++ b/src/pokemon/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { replacePokemonUrlParams } from "../lib/url";
 
 import { fetchPokemon } from "../lib/fetch";
+import { ERROR_MESSAGE } from "../constants/errorMessage";
 
 const app = new Hono();
 
@@ -21,7 +22,7 @@ app.get("/", async (c) => {
   if (!getPokemonData) {
     return new Response(
       JSON.stringify({
-        message: "Invalid request: Pokemon data not found",
+        message: ERROR_MESSAGE.NOT_FOUND,
         id: selectionQuery.id,
       }),
       {
@@ -33,7 +34,7 @@ app.get("/", async (c) => {
 
   return new Response(
     JSON.stringify({
-      message: "success",
+      message: ERROR_MESSAGE.SUCCESS,
       id: selectionQuery.id,
       pokemonData: getPokemonData,
     }),

--- a/src/pokemon/index.ts
+++ b/src/pokemon/index.ts
@@ -3,44 +3,20 @@ import { replacePokemonUrlParams } from "../lib/url";
 
 import { fetchAllPokemon, fetchPokemon } from "../lib/fetch";
 import { ERROR_MESSAGE } from "../constants/errorMessage";
+import { requestId } from "hono/request-id";
 
 const app = new Hono();
+app.use("*", requestId());
 
 app.get("/", async (c) => {
-  const q = c.req.query();
-  const selectionQuery = replacePokemonUrlParams(q);
-
-  // const pokemonIndex = await fetchAllPokemon();
-  // console.log("Fetched Pokemon data:", pokemonIndex);
-
-  // データを取得
-  const getPokemonData = selectionQuery.id
-    ? await fetchPokemon({ id: selectionQuery.id }).catch((error) => {
-        console.error("Error fetching Pokemon data:", error);
-        return null; // エラー時には null を返す
-      })
-    : null;
+  const pokemonList = await fetchAllPokemon(30);
 
   // データが null の場合は 400 を返す
-  // if (!selectionQuery.id) {
-  //   return new Response(
-  //     JSON.stringify({
-  //       message: ERROR_MESSAGE.NOT_FOUND,
-  //       pokemonData: pokemonIndex,
-  //     }),
-  //     {
-  //       headers: { "Content-Type": "application/json" },
-  //       status: 400,
-  //     }
-  //   );
-  // }
-
-  // データが null の場合は 400 を返す
-  if (!getPokemonData) {
+  if (!pokemonList) {
     return new Response(
       JSON.stringify({
         message: ERROR_MESSAGE.NOT_FOUND,
-        id: selectionQuery.id,
+        pokemonData: pokemonList,
       }),
       {
         headers: { "Content-Type": "application/json" },
@@ -52,7 +28,43 @@ app.get("/", async (c) => {
   return new Response(
     JSON.stringify({
       message: ERROR_MESSAGE.SUCCESS,
-      id: selectionQuery.id,
+      pokemonData: pokemonList,
+    }),
+    {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    }
+  );
+});
+
+// 動的パス定義
+app.get("/:id", async (c) => {
+  const id = c.req.param("id"); // URL の ":id" 部分を取得
+  // データを取得
+  const getPokemonData = id
+    ? await fetchPokemon({ id }).catch((error) => {
+        console.error("Error fetching Pokemon data:", error);
+        return null; // エラー時には null を返す
+      })
+    : null;
+
+  // データが null の場合は 400 を返す
+  if (!getPokemonData) {
+    return new Response(
+      JSON.stringify({
+        message: ERROR_MESSAGE.NOT_FOUND,
+        id,
+      }),
+      {
+        headers: { "Content-Type": "application/json" },
+        status: 400,
+      }
+    );
+  }
+  return new Response(
+    JSON.stringify({
+      message: ERROR_MESSAGE.SUCCESS,
+      id,
       pokemonData: getPokemonData,
     }),
     {

--- a/src/pokemon/index.ts
+++ b/src/pokemon/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { replacePokemonUrlParams } from "../lib/url";
 
-import { fetchPokemon } from "../lib/fetch";
+import { fetchAllPokemon, fetchPokemon } from "../lib/fetch";
 import { ERROR_MESSAGE } from "../constants/errorMessage";
 
 const app = new Hono();
@@ -10,6 +10,9 @@ app.get("/", async (c) => {
   const q = c.req.query();
   const selectionQuery = replacePokemonUrlParams(q);
 
+  // const pokemonIndex = await fetchAllPokemon();
+  // console.log("Fetched Pokemon data:", pokemonIndex);
+
   // データを取得
   const getPokemonData = selectionQuery.id
     ? await fetchPokemon({ id: selectionQuery.id }).catch((error) => {
@@ -17,6 +20,20 @@ app.get("/", async (c) => {
         return null; // エラー時には null を返す
       })
     : null;
+
+  // データが null の場合は 400 を返す
+  // if (!selectionQuery.id) {
+  //   return new Response(
+  //     JSON.stringify({
+  //       message: ERROR_MESSAGE.NOT_FOUND,
+  //       pokemonData: pokemonIndex,
+  //     }),
+  //     {
+  //       headers: { "Content-Type": "application/json" },
+  //       status: 400,
+  //     }
+  //   );
+  // }
 
   // データが null の場合は 400 を返す
   if (!getPokemonData) {

--- a/src/type/convertPokemon.ts
+++ b/src/type/convertPokemon.ts
@@ -1,0 +1,81 @@
+// 定義: 通常のスプライトの型
+type Sprite = string | null;
+
+// 定義: official-artwork の型
+interface OfficialArtwork {
+  front_default: string;
+  front_shiny: string;
+}
+
+// 定義: other の型
+interface SpritesType {
+  dream_world: Record<string, unknown>;
+  home: Record<string, unknown>;
+  officialArtwork: OfficialArtwork;
+  showdown: {
+    back_default: Sprite;
+    back_female: Sprite;
+    back_shiny: Sprite;
+    back_shiny_female: Sprite;
+    front_default: Sprite;
+    front_female: Sprite;
+    front_shiny: Sprite;
+    front_shiny_female: Sprite;
+  };
+}
+
+// 定義: 各statの詳細型
+interface StatDetail {
+  name: string;
+  url: string;
+}
+
+// 定義: stats配列内の要素型
+interface Stat {
+  base_stat: number;
+  effort: number;
+  stat: StatDetail;
+}
+
+// 定義: stats配列全体型
+export type StatsType = Stat[];
+
+// 定義: 各typeの詳細型
+interface TypeDetail {
+  name: string;
+  url: string;
+}
+
+// 定義: types配列内の要素型
+interface PokemonType {
+  slot: number;
+  type: TypeDetail;
+}
+
+// 定義: types配列全体型
+type Types = PokemonType[];
+
+// TODO: 不足部分がある（オブジェクト系）
+export type PokemonDataType = {
+  id: number;
+  weight: number;
+  height: number;
+  baseExperience: number;
+  is_default: boolean;
+  name: string;
+  order: number;
+  locationAreaEncounters: string;
+  sprites: SpritesType;
+  stats: StatsType;
+  types: Types;
+};
+
+/**
+ * コンバートして必要なところだけ抽出した型定義
+ */
+export type ConvertPokemonDataType = {
+  id: number;
+  sprites: SpritesType;
+  stats: StatsType;
+  types: Types;
+};

--- a/src/type/convertPokemon.ts
+++ b/src/type/convertPokemon.ts
@@ -8,20 +8,18 @@ interface OfficialArtwork {
 }
 
 // 定義: other の型
-interface SpritesType {
+export interface SpritesType {
   dream_world: Record<string, unknown>;
   home: Record<string, unknown>;
-  officialArtwork: OfficialArtwork;
-  showdown: {
-    back_default: Sprite;
-    back_female: Sprite;
-    back_shiny: Sprite;
-    back_shiny_female: Sprite;
-    front_default: Sprite;
-    front_female: Sprite;
-    front_shiny: Sprite;
-    front_shiny_female: Sprite;
-  };
+  other: { official_artwork: OfficialArtwork };
+  back_default: Sprite;
+  back_female: Sprite;
+  back_shiny: Sprite;
+  back_shiny_female: Sprite;
+  front_default: Sprite;
+  front_female: Sprite;
+  front_shiny: Sprite;
+  front_shiny_female: Sprite;
 }
 
 // 定義: 各statの詳細型
@@ -78,4 +76,13 @@ export type ConvertPokemonDataType = {
   sprites: SpritesType;
   stats: StatsType;
   types: Types;
+};
+
+type ResponseMessage = string;
+type RequestId = string;
+
+export type GetPokemonDataType = {
+  id: RequestId;
+  message: ResponseMessage;
+  pokemonData: ConvertPokemonDataType;
 };

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,0 +1,1 @@
+export type pokemonID = string;

--- a/src/type/pokemon.d.ts
+++ b/src/type/pokemon.d.ts
@@ -1,0 +1,60 @@
+declare type ProcessedPokemon = {
+  id: string;
+  name: string | undefined;
+  image: string | undefined;
+};
+
+declare type ProcessedPokemonList = ProcessedPokemon[];
+
+declare type ListPageItem = {
+  processedPokemonList: ProcessedPokemonList;
+  nextUrl: string;
+};
+
+declare type DetailPokemon = {
+  id: string;
+  name: string | undefined;
+  genera: string | undefined;
+  image: string | undefined;
+  types: string[] | undefined;
+  abilities: string[] | undefined;
+};
+
+declare type PokemonOutline = {
+  name: string;
+  url: string;
+};
+declare type PokemonList = PokemonOutline[];
+
+declare type Pokemon = {
+  sprites: { other: { "official-artwork": { front_default: string } } };
+  abilities: { ability: { url: string } }[];
+  types: { type: { url: string } }[];
+};
+
+declare type PokemonListData = {
+  next: string;
+  results: PokemonList;
+};
+
+declare type languageNameObject = {
+  name: string;
+  language: { name: string };
+};
+declare type Ability = languageNameObject[];
+declare type Type = languageNameObject[];
+declare type Names = languageNameObject[];
+
+declare type languageGenusObject = {
+  genus: string;
+  language: { name: string };
+};
+declare type Genera = languageGenusObject[];
+
+declare type FetchType = { data: { names: languageNameObject[] } };
+declare type FetchAbilities = FetchType;
+
+declare type PokemonSpecies = {
+  names: Names;
+  genera: Genera;
+};

--- a/src/type/pokemonSpecoes.d.ts
+++ b/src/type/pokemonSpecoes.d.ts
@@ -1,0 +1,16 @@
+export type SpeciesType = {
+  language: {
+    name: string;
+    url: string;
+  };
+};
+export type SpeciesListType = Array<SpeciesType>;
+
+export type PokemonSpecies = {
+  name: string;
+  id: number;
+  is_baby: boolean;
+  is_legendary: boolean;
+  is_mythical: boolean;
+  names: SpeciesListType;
+};


### PR DESCRIPTION
- feat: ざっくりとしたapi作成作成
- update: error message const
- update: convertdata
- feat: 一部がスネークケースになってなかったので修正修正
- update: 日本語の名前を取得するようにした
- test: 仮置き
- update: 一覧用と個別ようでルーティング切り分け


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- Pokémonデータに関連するエラーメッセージと成功メッセージを管理する新しい定数`ERROR_MESSAGE`を追加。
	- Pokémon APIのベースURLを設定し、関連エンドポイントを整理した新しい定数`BASE_URL`を導入。
	- Pokémonデータを変換・選択する機能を持つ`convertPokemonData`関数を追加。
	- Pokémonデータを取得するための非同期関数`fetchPokemon`と`fetchAllPokemon`を導入。
	- リクエストIDを生成するミドルウェアを追加し、Pokémonリストと個別データを取得するためのルートを設定。
	- PokémonのIDを取得するための新しい動的ルートを追加。

- **バグ修正**
	- エラーハンドリングを強化し、適切なHTTPステータスを返すように修正。

- **ドキュメント**
	- 新しい関数や定数に関するJSDocコメントを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->